### PR TITLE
Expired cards are moved from the Today column to other columns

### DIFF
--- a/src/main/scala/com/manenkov/assistant/domain/trello/DateUtils.scala
+++ b/src/main/scala/com/manenkov/assistant/domain/trello/DateUtils.scala
@@ -52,7 +52,7 @@ case class DateUtils(timeZoneCorrection: Integer) {
   }
 
   def isOverdue(date: LocalDateTime): Boolean = {
-    val now = plusTimezoneCorrection(LocalDateTime.now().`with`(LocalTime.MIN))
+    val now = plusTimezoneCorrection(LocalDateTime.now()).`with`(LocalTime.MIN)
     date.isBefore(now)
   }
 


### PR DESCRIPTION
**Problem:** 

Expired cards are moved from the Today column to other columns.

**Solution:**

Fix `isOverdue` method at `DateUtils`. Add timezone shift to current time.
