### PR TITLE
Fix growing offset before tech info section

### DIFF
--- a/src/main/scala/com/manenkov/assistant/domain/trello/TrelloService.scala
+++ b/src/main/scala/com/manenkov/assistant/domain/trello/TrelloService.scala
@@ -394,11 +394,9 @@ class TrelloService[F[_]](trelloRepo: TrelloRepositoryAlgebra[F], conf: Assistan
     }
 
     cardDescription.substring(0, firstIdx) ++
-      s"""
-        |```
+      s"""```
         |$json
-        |```
-        |""".stripMargin
+        |```""".stripMargin
   }
 
   private def cardToCardInternal(cards: Seq[Card]): Seq[CardInternal] = {


### PR DESCRIPTION
**Problem:**

Tech info section moves down on every card update.

```
---
_Tech info for assistant (don't touch):_

\```
{"pin":true,"testCreatedAt":"2022-05-20T08:14:33.186883"}
\```
 ```

changes to:

```
---
_Tech info for assistant (don't touch):_


\```
{"pin":true,"testCreatedAt":"2022-05-20T08:14:33.186883"}
\```
```

**Solution:**

Don't add newline before techinfo section at `makeCardDescription` method